### PR TITLE
Allow a custom policy document to be passed in

### DIFF
--- a/iam-policies.tf
+++ b/iam-policies.tf
@@ -57,3 +57,16 @@ resource "aws_iam_role_policy_attachment" "amazoneks_efs_csi_driver_policy_attac
   role       = aws_iam_role.this[0].name
   policy_arn = aws_iam_policy.amazoneks_efs_csi_driver_policy[0].arn
 }
+
+resource "aws_iam_policy" "custom" {
+  count       = var.create_role && var.custom_policy != "" ? 1 : 0
+  name_prefix = "${var.policy_name_prefix}Custom-"
+  path        = var.role_path
+  policy      = var.custom_policy
+}
+
+resource "aws_iam_role_policy_attachment" "custom" {
+  count      = var.create_role && var.custom_policy != "" ? 1 : 0
+  role       = aws_iam_role.this[0].name
+  policy_arn = aws_iam_policy.custom[0].arn
+}

--- a/iam-policies.tf
+++ b/iam-policies.tf
@@ -60,7 +60,7 @@ resource "aws_iam_role_policy_attachment" "amazoneks_efs_csi_driver_policy_attac
 
 resource "aws_iam_policy" "custom" {
   count       = var.create_role && var.custom_policy != "" ? 1 : 0
-  name_prefix = "${var.policy_name_prefix}Custom-"
+  name_prefix = "${var.namespace}-${var.name}-"
   path        = var.role_path
   policy      = var.custom_policy
 }

--- a/variables.tf
+++ b/variables.tf
@@ -437,3 +437,9 @@ variable "module_opts" {
   default     = ""
   description = "Additional java options for JVM"
 }
+
+variable "custom_policy" {
+  type        = string
+  description = "Custom IAM policy document to attach to the role"
+  default     = ""
+}


### PR DESCRIPTION
It is not possible to create an actual policy and pass in the ARN with the current version of Terraform, but passing
in a policy document should work.
